### PR TITLE
Force install SQLAlchemy==1.13.15

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,12 @@
     state: present
   with_flattened: "{{ airflow_plugins|map(attribute='required_pips')|list }}"
 
+- name: Force install SQLAlchemy==1.13.15
+  pip:
+    name: 'SQLAlchemy==1.13.15'
+    executable: '{{ airflow_pip }}'
+    state: forcereinstall
+
 - name: Uninstall old airflow package
   pip:
     name: 'airflow'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,12 +69,6 @@
     state: present
   with_flattened: "{{ airflow_plugins|map(attribute='required_pips')|list }}"
 
-- name: Force install SQLAlchemy==1.13.15
-  pip:
-    name: 'SQLAlchemy==1.13.15'
-    executable: '{{ airflow_pip }}'
-    state: forcereinstall
-
 - name: Uninstall old airflow package
   pip:
     name: 'airflow'
@@ -94,6 +88,12 @@
     executable: '{{ airflow_pip }}'
     state: present
   with_items: "{{ airflow_additional_pip_packages }}"
+
+- name: Force install SQLAlchemy==1.13.15
+  pip:
+    name: 'SQLAlchemy==1.13.15'
+    executable: '{{ airflow_pip }}'
+    state: forcereinstall
 
 - name: Fix Python path in Airflow scripts
   lineinfile:


### PR DESCRIPTION
Airflow's webserver is incompatible with SQLAlchemy 1.13.16 (see https://stackoverflow.com/questions/61101729/starting-airflow-webserver-fails-with-sqlalchemy-exc-noinspectionavailable-no-i among others). This commit explicitly installs SQLAlchemy 1.13.15.